### PR TITLE
re-enabling token-baed auth for movies endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ app.get('/users', passport.authenticate('jwt',{session:false}), (req, res) => {
     });
 });
 
-app.get('/movies', (req, res) => {
+app.get('/movies', passport.authenticate('jwt',{session:false}), (req, res) => {
   Movies.find({ Movies: req.params.Movies })
     .then((movies) => {
       res.json(movies);


### PR DESCRIPTION
re-enabling token-based authentication for GET all movies request. this was temporarily removed to test function in REACT .